### PR TITLE
Added option to configure the led state

### DIFF
--- a/nodemcu/lua/config.lua
+++ b/nodemcu/lua/config.lua
@@ -4,6 +4,9 @@ local module = {}
 module.Model = "BME"
 module.Version = "1.4"
 
+-- LED state
+module.ledState = 1 -- 0: fully disabled, 1: LEDs on, 2: Connected off (Boot/Error only)
+
 -- BME280 settings
 
 module.bme280scl = 5  -- D5

--- a/nodemcu/lua/led.lua
+++ b/nodemcu/lua/led.lua
@@ -3,6 +3,9 @@ local module = {}
 local mode = 0
 
 local function start()
+  if config.ledState == 0 then
+    return
+  end
 
   gpio.mode(config.ledBlue, gpio.OUTPUT)
   gpio.mode(config.ledRed, gpio.OUTPUT)
@@ -16,8 +19,13 @@ local function start()
           gpio.write(config.ledRed, gpio.HIGH)
         end
         if mode == 1 then
-          gpio.write(config.ledBlue, gpio.LOW)
-          gpio.write(config.ledRed, gpio.HIGH)
+          if config.ledState == 1 then
+            gpio.write(config.ledBlue, gpio.LOW)
+            gpio.write(config.ledRed, gpio.HIGH)
+          else
+            gpio.write(config.ledBlue, gpio.HIGH)
+            gpio.write(config.ledRed, gpio.HIGH)
+          end
         end
         if mode == 2 then
           gpio.write(config.ledBlue, gpio.HIGH)
@@ -57,6 +65,10 @@ function module.error()
 end
 
 function module.flashRed()
+  if config.ledState == 0 then
+    return
+  end
+  
   gpio.write(config.ledRed, gpio.LOW)
   tmr.alarm(1,200,tmr.ALARM_SINGLE,function()
       gpio.write(config.ledRed, gpio.HIGH)


### PR DESCRIPTION
This change is required to be able to use the code on a ESP-01 (just two GPIO pins) and a nice to have in case you want to avoid illuminating a dark room with (blinking) blue LEDs.